### PR TITLE
Make UUVM_Light usable as an hdlmake module

### DIFF
--- a/Manifest.py
+++ b/Manifest.py
@@ -1,0 +1,3 @@
+modules = {
+    "local": ["src_util",
+              "src_bfm"]}

--- a/demo_tb/Manifest.py
+++ b/demo_tb/Manifest.py
@@ -1,0 +1,5 @@
+files = ['demo_tb.vhd',
+         'dut/irqc.vhd',
+         'dut/irqc_pif.vhd',
+         'dut/irqc_core.vhd',
+         'dut/irqc_pif_pkg.vhd']

--- a/sim/Manifest.py
+++ b/sim/Manifest.py
@@ -1,0 +1,7 @@
+action = "simulation"
+sim_tool = "ghdl"
+sim_top = "demo_tb"
+ghdl_opt = "--std=08 -frelaxed-rules"
+
+modules = {'local': ['..',
+                     '../demo_tb']}

--- a/src_bfm/Manifest.py
+++ b/src_bfm/Manifest.py
@@ -1,0 +1,12 @@
+files = ['avalon_mm_bfm_pkg.vhd',
+         'avalon_st_bfm_pkg.vhd',
+         'axilite_bfm_pkg.vhd',
+         'axistream_bfm_pkg.vhd',
+         'gmii_bfm_pkg.vhd',
+         'gpio_bfm_pkg.vhd',
+         'i2c_bfm_pkg.vhd',
+         'rgmii_bfm_pkg.vhd',
+         'sbi_bfm_pkg.vhd',
+         'spi_bfm_pkg.vhd',
+         'uart_bfm_pkg.vhd',
+]

--- a/src_util/Manifest.py
+++ b/src_util/Manifest.py
@@ -1,0 +1,14 @@
+files = ['types_pkg.vhd',
+         'adaptations_pkg.vhd',
+         'string_methods_pkg.vhd',
+         'protected_types_pkg.vhd',
+         'global_signals_and_shared_variables_pkg.vhd',
+         'hierarchy_linked_list_pkg.vhd',
+         'alert_hierarchy_pkg.vhd',
+         'license_pkg.vhd',
+         'methods_pkg.vhd',
+         'bfm_common_pkg.vhd',
+         'uvvm_util_context.vhd',
+]
+
+library = 'uvvm_util'


### PR DESCRIPTION
By adding these Manifest.py files, UUVM_Light can be used as an [hdlmake](https://hdlmake.readthedocs.io) module directly. Then, an hdlmake user would just need to add the following snippet to automatically fetch UUVM_Light and add it to the compilation scripts.

```
modules = {'git': 'git:https://github.com/UVVM/UVVM_Light.git'}
fetchto = '../sim_lib_dir/'
```