### PR TITLE
include unconditionally all vhd files in manifests

### DIFF
--- a/src_bfm/Manifest.py
+++ b/src_bfm/Manifest.py
@@ -1,12 +1,3 @@
-files = ['avalon_mm_bfm_pkg.vhd',
-         'avalon_st_bfm_pkg.vhd',
-         'axilite_bfm_pkg.vhd',
-         'axistream_bfm_pkg.vhd',
-         'gmii_bfm_pkg.vhd',
-         'gpio_bfm_pkg.vhd',
-         'i2c_bfm_pkg.vhd',
-         'rgmii_bfm_pkg.vhd',
-         'sbi_bfm_pkg.vhd',
-         'spi_bfm_pkg.vhd',
-         'uart_bfm_pkg.vhd',
+files = [
+    "*.vhd",
 ]

--- a/src_util/Manifest.py
+++ b/src_util/Manifest.py
@@ -1,14 +1,5 @@
-files = ['types_pkg.vhd',
-         'adaptations_pkg.vhd',
-         'string_methods_pkg.vhd',
-         'protected_types_pkg.vhd',
-         'global_signals_and_shared_variables_pkg.vhd',
-         'hierarchy_linked_list_pkg.vhd',
-         'alert_hierarchy_pkg.vhd',
-         'license_pkg.vhd',
-         'methods_pkg.vhd',
-         'bfm_common_pkg.vhd',
-         'uvvm_util_context.vhd',
+files = [
+    "*.vhd",
 ]
 
 library = 'uvvm_util'


### PR DESCRIPTION
With current version, running

	cd sim
	hdlmake
	make

breaks, as there are missing files in the files array.